### PR TITLE
Refactors slightly some functions

### DIFF
--- a/pkg/processing/metrics.go
+++ b/pkg/processing/metrics.go
@@ -1,7 +1,10 @@
 package processing
 
 import (
+	"strings"
+
 	"github.com/JoaoBraveCoding/prom-storage-analysis/pkg/parser"
+	"github.com/JoaoBraveCoding/prom-storage-analysis/pkg/prom"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
@@ -25,4 +28,25 @@ func MetricIdentifiers(metric string, metricMetadata []v1.MetricMetadata) map[st
 		identifiers[identifier] = struct{}{}
 	}
 	return identifiers
+}
+
+// BuilMetricsIdentifiers build a map with metrics and possible identifiers.
+// An identifier is the concatenation of the values namespace + / + job
+// that we get for each metric using the Targets Metadata endpoint
+func BuilMetricsIdentifiers(metrics []string) map[string]map[string]struct{} {
+	metricsIdentifiers := make(map[string]map[string]struct{})
+	for _, metric := range metrics {
+		metricMetadata := prom.MetricMetadata(metric)
+		if len(metricMetadata) == 0 {
+			// Lookup for the parent metric name if it's a counter, histogram or summary.
+			for _, s := range []string{"_total", "_bucket", "_sum", "_count"} {
+				metricMetadata = prom.MetricMetadata(strings.TrimSuffix(metric, s))
+				if len(metricMetadata) > 0 {
+					break
+				}
+			}
+		}
+		metricsIdentifiers[metric] = MetricIdentifiers(metric, metricMetadata)
+	}
+	return metricsIdentifiers
 }


### PR DESCRIPTION
The goal of the refactoring is to allow some functions to receive only metrics with the goal of possibly using them with other sources of metrics other than prometheusRules